### PR TITLE
Support .ini file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Supported formats/extensions:
  * conf, sh: `export key=value` format
  * yaml, yml: YAML format. Arrays supported with indexes as `key.value.1: 1` and `key.value.2: 2`
  * properties: `key: properties`
+ * ini: `section.key=value` format converted to:
+   ```
+   [section]
+   key=value
+   ```
 
 Optional, the extension and the format could be different with the syntax:
 

--- a/app/transformation_test.go
+++ b/app/transformation_test.go
@@ -58,3 +58,15 @@ func TestToProperties(t *testing.T) {
 	assert.Equal(t, expected, result, "Results are not the expected")
 
 }
+
+func TestToIni(t *testing.T) {
+	input := map[string]string{
+		"section1.some.key":"value1",
+		"section2.other.key":"value2",
+		"section1.yet.another":"value3",
+	}
+	result := ToIni(input)
+	expected := "[section1]\nsome.key=value1\nyet.another=value3\n\n[section2]\nother.key=value2\n\n"
+
+	assert.Equal(t, expected, result, "Results are not the expected")
+}


### PR DESCRIPTION
I'd like to create [`ambari-agent.ini`](https://github.com/apache/ambari/blob/91462df2291e0cccccb5a1b66d006b9101307e9c/ambari-agent/conf/unix/ambari-agent.ini) via `envtoconf` in a container that uses [flokkr/launcher](https://github.com/flokkr/launcher).